### PR TITLE
read size from `tty`

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,0 +1,7 @@
+fn main() {
+    if let Some((w, h)) = termize::dimensions() {
+        println!("nice! your terminal is of {w}x{h} dimensions");
+    } else {
+        eprintln!("couldn't read terminal size :(");
+    }
+}

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -2,11 +2,12 @@
 #![allow(clippy::useless_conversion)]
 
 use libc::{STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO, TIOCGWINSZ, ioctl, winsize};
-use std::mem::zeroed;
+use std::{fs::File, mem::zeroed, os::fd::IntoRawFd};
 
 /// Runs the ioctl command. Returns (0, 0) if all of the streams are not to a terminal, or
 /// there is an error. (0, 0) is an invalid size to have anyway, which is why
 /// it can be used as a nil value.
+/// If none of `stdout`, `stdin` and `stderr` is a terminal, `/dev/tty` will be queried.
 unsafe fn get_dimensions_any() -> winsize {
     let mut window: winsize = unsafe { zeroed() };
     let mut result = unsafe { ioctl(STDOUT_FILENO, TIOCGWINSZ.into(), &mut window) };
@@ -18,7 +19,15 @@ unsafe fn get_dimensions_any() -> winsize {
             window = unsafe { zeroed() };
             result = unsafe { ioctl(STDERR_FILENO, TIOCGWINSZ.into(), &mut window) };
             if result == -1 {
-                return unsafe { zeroed() };
+                window = unsafe { zeroed() };
+                let Ok(tty) = File::options().read(true).open("/dev/tty") else {
+                    return unsafe { zeroed() };
+                };
+                let tty_fd = tty.into_raw_fd();
+                result = unsafe { ioctl(tty_fd, TIOCGWINSZ.into(), &mut window) };
+                if unsafe { libc::close(tty_fd) } == -1 || result == -1 {
+                    return unsafe { zeroed() };
+                }
             }
         }
     }

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::useless_conversion)]
 
 use libc::{STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO, TIOCGWINSZ, ioctl, winsize};
-use std::{fs::File, mem::zeroed, os::fd::IntoRawFd};
+use std::{fs::File, mem::zeroed, os::fd::AsRawFd};
 
 /// Runs the ioctl command. Returns (0, 0) if all of the streams are not to a terminal, or
 /// there is an error. (0, 0) is an invalid size to have anyway, which is why
@@ -23,9 +23,8 @@ unsafe fn get_dimensions_any() -> winsize {
                 let Ok(tty) = File::options().read(true).open("/dev/tty") else {
                     return unsafe { zeroed() };
                 };
-                let tty_fd = tty.into_raw_fd();
-                result = unsafe { ioctl(tty_fd, TIOCGWINSZ.into(), &mut window) };
-                if unsafe { libc::close(tty_fd) } == -1 || result == -1 {
+                result = unsafe { ioctl(tty.as_raw_fd(), TIOCGWINSZ.into(), &mut window) };
+                if result == -1 {
                     return unsafe { zeroed() };
                 }
             }


### PR DESCRIPTION
## why
it's more versatile, as if none of `stdin`, `stdout` and `stderr` are `tty`s, `/dev/tty` still is readable

> [!important]
> I have absolutely no idea why it works and how and couldn't find any docs about it.
> it does though.

does it fix #19?

## works

```console
# NOTE: `termize-stdstreams` is the `basic.rs` example compiled on `v0.2.0`
# NOTE: `termize-tty` is the `basic.rs` example compiled on the `jarjk/master` branch

# NOTE: all of `stdin`, `stdout` and `stderr` are `tty`s
$ ./termize-stdstreams && ./termize-tty
nice! your terminal is of 110x34 dimensions
nice! your terminal is of 110x34 dimensions

# NOTE: `stdin` is not a `tty` anymore, while `stdout` and `stderr` are
$ echo stdin-notatty | ./termize-stdstreams && echo stdin-notatty | ./termize-tty
nice! your terminal is of 110x34 dimensions
nice! your terminal is of 110x34 dimensions

# NOTE: `stdin` and `stdout` are no `tty`s anymore, while `stderr` is
$ echo stdin-notatty | ./termize-stdstreams | cat && echo stdin-notatty | ./termize-tty | cat
nice! your terminal is of 110x34 dimensions
nice! your terminal is of 110x34 dimensions

# NOTE: none of `stdin`, `stdout` and `stderr` are `tty`s, yet `/dev/tty` can still be queried
$ echo stdin-notatty | ./termize-stdstreams &| cat && echo stdin-notatty | ./termize-tty &| cat
couldn't read terminal size :(
nice! your terminal is of 110x34 dimensions
```

## commits
- **refactor(unix): `get_dimensions_any()` reads from tty**
- **chore: add a basic example**
